### PR TITLE
Add client package for protocol handler integration

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,89 @@
+// Package client provides a gRPC client for the session-manager service.
+//
+// Protocol handlers (pop3d, imapd, smtpd) use this package to authenticate
+// users and access mailboxes through the session-manager rather than spawning
+// mail-session processes directly.
+//
+// Usage:
+//
+//	c, err := client.Dial("/run/session-manager/session-manager.sock")
+//	token, mailbox, err := c.Login(ctx, "user@example.com", "secret")
+//	store := c.NewMessageStore(token)
+//	// ... use store for mailbox operations ...
+//	_ = c.Logout(ctx, token)
+//	_ = c.Close()
+package client
+
+import (
+	"fmt"
+
+	"context"
+
+	pb "github.com/infodancer/mail-session/proto/mailsession/v1"
+	smpb "github.com/infodancer/session-manager/proto/sessionmanager/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Client holds a connection to the session-manager gRPC server.
+type Client struct {
+	conn    *grpc.ClientConn
+	session smpb.SessionServiceClient
+	mailbox pb.MailboxServiceClient
+	folders pb.FolderServiceClient
+}
+
+// Dial connects to the session-manager over a unix domain socket.
+func Dial(socketPath string) (*Client, error) {
+	conn, err := grpc.NewClient(
+		"unix://"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dial session-manager %q: %w", socketPath, err)
+	}
+	return &Client{
+		conn:    conn,
+		session: smpb.NewSessionServiceClient(conn),
+		mailbox: pb.NewMailboxServiceClient(conn),
+		folders: pb.NewFolderServiceClient(conn),
+	}, nil
+}
+
+// Login authenticates a user and creates a mail session.
+// Returns the opaque session token and the authenticated mailbox identifier.
+// The token must be passed to NewMessageStore and to Logout.
+func (c *Client) Login(ctx context.Context, username, password string) (token, mailbox string, err error) {
+	resp, err := c.session.Login(ctx, &smpb.LoginRequest{
+		Username: username,
+		Password: password,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("session-manager login: %w", err)
+	}
+	return resp.GetSessionToken(), resp.GetMailbox(), nil
+}
+
+// Logout releases a session. When the last reference to a session is released,
+// an idle timer starts; if no new Login arrives before it fires, the
+// mail-session process is terminated.
+func (c *Client) Logout(ctx context.Context, token string) error {
+	_, err := c.session.Logout(ctx, &smpb.LogoutRequest{SessionToken: token})
+	return err
+}
+
+// NewMessageStore returns a msgstore.MessageStore backed by the session-manager.
+// All operations are routed to the per-user mail-session associated with token.
+// The returned store is safe to use concurrently.
+func (c *Client) NewMessageStore(token string) *MessageStore {
+	return &MessageStore{
+		token:   token,
+		mailbox: c.mailbox,
+		folders: c.folders,
+	}
+}
+
+// Close closes the underlying gRPC connection.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}

--- a/client/store.go
+++ b/client/store.go
@@ -1,0 +1,273 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	pb "github.com/infodancer/mail-session/proto/mailsession/v1"
+	"github.com/infodancer/msgstore"
+	"google.golang.org/grpc/metadata"
+)
+
+// MessageStore implements msgstore.MessageStore and msgstore.FolderStore by
+// proxying gRPC calls through the session-manager. Each call attaches the
+// session token as gRPC metadata so the server can route to the correct
+// per-user mail-session.
+type MessageStore struct {
+	token   string
+	mailbox pb.MailboxServiceClient
+	folders pb.FolderServiceClient
+}
+
+// tokenCtx injects the session token into the outgoing gRPC metadata.
+func (s *MessageStore) tokenCtx(ctx context.Context) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, "session-token", s.token)
+}
+
+// ── msgstore.MessageStore ─────────────────────────────────────────────────────
+
+// List returns message metadata for INBOX.
+func (s *MessageStore) List(ctx context.Context, _ string) ([]msgstore.MessageInfo, error) {
+	return s.ListInFolder(ctx, "", "INBOX")
+}
+
+// Stat returns message count and total size for INBOX.
+func (s *MessageStore) Stat(ctx context.Context, _ string) (int, int64, error) {
+	return s.StatFolder(ctx, "", "INBOX")
+}
+
+// Retrieve returns the full message content from INBOX by UID.
+func (s *MessageStore) Retrieve(ctx context.Context, _ string, uid string) (io.ReadCloser, error) {
+	return s.RetrieveFromFolder(ctx, "", "INBOX", uid)
+}
+
+// Delete marks a message in INBOX for POP3-style deletion.
+func (s *MessageStore) Delete(ctx context.Context, _ string, uid string) error {
+	_, err := s.mailbox.Delete(s.tokenCtx(ctx), &pb.DeleteRequest{Uid: uid})
+	return err
+}
+
+// Expunge commits all POP3 deletions in INBOX.
+func (s *MessageStore) Expunge(ctx context.Context, _ string) error {
+	_, err := s.mailbox.Commit(s.tokenCtx(ctx), &pb.CommitRequest{})
+	return err
+}
+
+// ── msgstore.FolderStore ──────────────────────────────────────────────────────
+
+// ListFolders returns all folder names.
+func (s *MessageStore) ListFolders(ctx context.Context, _ string) ([]string, error) {
+	resp, err := s.folders.ListFolders(s.tokenCtx(ctx), &pb.ListFoldersRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetFolders(), nil
+}
+
+// CreateFolder creates a new folder.
+func (s *MessageStore) CreateFolder(ctx context.Context, _ string, folder string) error {
+	_, err := s.folders.CreateFolder(s.tokenCtx(ctx), &pb.CreateFolderRequest{Name: folder})
+	return err
+}
+
+// DeleteFolder removes a folder.
+func (s *MessageStore) DeleteFolder(ctx context.Context, _ string, folder string) error {
+	_, err := s.folders.DeleteFolder(s.tokenCtx(ctx), &pb.DeleteFolderRequest{Name: folder})
+	return err
+}
+
+// RenameFolder renames a folder.
+func (s *MessageStore) RenameFolder(ctx context.Context, _ string, oldName, newName string) error {
+	_, err := s.folders.RenameFolder(s.tokenCtx(ctx), &pb.RenameFolderRequest{OldName: oldName, NewName: newName})
+	return err
+}
+
+// ListInFolder returns message metadata for the given folder.
+func (s *MessageStore) ListInFolder(ctx context.Context, _ string, folder string) ([]msgstore.MessageInfo, error) {
+	resp, err := s.mailbox.List(s.tokenCtx(ctx), &pb.ListRequest{Folder: folder})
+	if err != nil {
+		return nil, err
+	}
+	msgs := make([]msgstore.MessageInfo, 0, len(resp.GetMessages()))
+	for _, m := range resp.GetMessages() {
+		msgs = append(msgs, msgstore.MessageInfo{
+			UID:   m.GetUid(),
+			Size:  m.GetSize(),
+			Flags: m.GetFlags(),
+		})
+	}
+	return msgs, nil
+}
+
+// StatFolder returns message count and total size for the given folder.
+func (s *MessageStore) StatFolder(ctx context.Context, _ string, folder string) (int, int64, error) {
+	resp, err := s.mailbox.Stat(s.tokenCtx(ctx), &pb.StatRequest{Folder: folder})
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(resp.GetCount()), resp.GetTotalBytes(), nil
+}
+
+// RetrieveFromFolder returns the full message content from the given folder.
+func (s *MessageStore) RetrieveFromFolder(ctx context.Context, _ string, folder, uid string) (io.ReadCloser, error) {
+	stream, err := s.mailbox.Fetch(s.tokenCtx(ctx), &pb.FetchRequest{Folder: folder, Uid: uid})
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(chunk.GetData())
+	}
+	return io.NopCloser(&buf), nil
+}
+
+// DeleteInFolder marks a message in a folder for IMAP-style deletion.
+func (s *MessageStore) DeleteInFolder(ctx context.Context, _ string, folder, uid string) error {
+	_, err := s.mailbox.SetFlags(s.tokenCtx(ctx), &pb.SetFlagsRequest{
+		Folder: folder,
+		Uid:    uid,
+		Flags:  []string{`\Deleted`},
+	})
+	return err
+}
+
+// ExpungeFolder removes all \Deleted messages from a folder.
+func (s *MessageStore) ExpungeFolder(ctx context.Context, _ string, folder string) error {
+	_, err := s.mailbox.Expunge(s.tokenCtx(ctx), &pb.ExpungeRequest{Folder: folder})
+	return err
+}
+
+// DeliverToFolder delivers a message to a folder.
+func (s *MessageStore) DeliverToFolder(ctx context.Context, _ string, folder string, message io.Reader) error {
+	data, err := io.ReadAll(message)
+	if err != nil {
+		return fmt.Errorf("read message: %w", err)
+	}
+	stream, err := s.mailbox.Append(s.tokenCtx(ctx))
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&pb.AppendRequest{
+		Payload: &pb.AppendRequest_Metadata{
+			Metadata: &pb.AppendMetadata{Folder: folder, Date: time.Now().Format(time.RFC3339)},
+		},
+	}); err != nil {
+		return err
+	}
+	for off := 0; off < len(data); {
+		end := off + 64*1024
+		if end > len(data) {
+			end = len(data)
+		}
+		if err := stream.Send(&pb.AppendRequest{
+			Payload: &pb.AppendRequest_Data{Data: data[off:end]},
+		}); err != nil {
+			return err
+		}
+		off = end
+	}
+	_, err = stream.CloseAndRecv()
+	return err
+}
+
+// AppendToFolder stores a message with explicit flags and date.
+func (s *MessageStore) AppendToFolder(ctx context.Context, _ string, folder string, r io.Reader, flags []string, date time.Time) (string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("read message: %w", err)
+	}
+	stream, err := s.mailbox.Append(s.tokenCtx(ctx))
+	if err != nil {
+		return "", err
+	}
+	if err := stream.Send(&pb.AppendRequest{
+		Payload: &pb.AppendRequest_Metadata{
+			Metadata: &pb.AppendMetadata{Folder: folder, Flags: flags, Date: date.Format(time.RFC3339)},
+		},
+	}); err != nil {
+		return "", err
+	}
+	for off := 0; off < len(data); {
+		end := off + 64*1024
+		if end > len(data) {
+			end = len(data)
+		}
+		if err := stream.Send(&pb.AppendRequest{
+			Payload: &pb.AppendRequest_Data{Data: data[off:end]},
+		}); err != nil {
+			return "", err
+		}
+		off = end
+	}
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		return "", err
+	}
+	return resp.GetUid(), nil
+}
+
+// SetFlagsInFolder replaces the flag set on a message.
+func (s *MessageStore) SetFlagsInFolder(ctx context.Context, _ string, folder, uid string, flags []string) error {
+	_, err := s.mailbox.SetFlags(s.tokenCtx(ctx), &pb.SetFlagsRequest{Folder: folder, Uid: uid, Flags: flags})
+	return err
+}
+
+// CopyMessage copies a message between folders, returning the new UID.
+func (s *MessageStore) CopyMessage(ctx context.Context, _ string, srcFolder, uid, destFolder string) (string, error) {
+	resp, err := s.mailbox.Copy(s.tokenCtx(ctx), &pb.CopyRequest{Folder: srcFolder, Uid: uid, DestFolder: destFolder})
+	if err != nil {
+		return "", err
+	}
+	return resp.GetNewUid(), nil
+}
+
+// MoveMessage atomically moves a message between folders, returning the new UID.
+func (s *MessageStore) MoveMessage(ctx context.Context, _ string, srcFolder, uid, destFolder string) (string, error) {
+	resp, err := s.mailbox.Move(s.tokenCtx(ctx), &pb.MoveRequest{SrcFolder: srcFolder, Uid: uid, DestFolder: destFolder})
+	if err != nil {
+		return "", err
+	}
+	return resp.GetNewUid(), nil
+}
+
+// UIDValidity returns the UIDVALIDITY for a folder.
+func (s *MessageStore) UIDValidity(ctx context.Context, _ string, folder string) (uint32, error) {
+	resp, err := s.mailbox.UIDValidity(s.tokenCtx(ctx), &pb.UIDValidityRequest{Folder: folder})
+	if err != nil {
+		return 0, err
+	}
+	return resp.GetUidValidity(), nil
+}
+
+// Rescan re-reads a folder and returns messages that appeared since the last call.
+func (s *MessageStore) Rescan(ctx context.Context, folder string) ([]msgstore.MessageInfo, error) {
+	resp, err := s.mailbox.Rescan(s.tokenCtx(ctx), &pb.RescanRequest{Folder: folder})
+	if err != nil {
+		return nil, err
+	}
+	msgs := make([]msgstore.MessageInfo, 0, len(resp.GetNewMessages()))
+	for _, m := range resp.GetNewMessages() {
+		msgs = append(msgs, msgstore.MessageInfo{
+			UID:   m.GetUid(),
+			Size:  m.GetSize(),
+			Flags: m.GetFlags(),
+		})
+	}
+	return msgs, nil
+}
+
+// Compile-time interface checks.
+var (
+	_ msgstore.MessageStore = (*MessageStore)(nil)
+	_ msgstore.FolderStore  = (*MessageStore)(nil)
+)

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.26.1
 require (
 	github.com/infodancer/auth v0.1.11
 	github.com/infodancer/mail-session v0.1.2
+	github.com/infodancer/msgstore v0.2.2-0.20260303202932-60ef82df8079
 	github.com/pelletier/go-toml/v2 v2.2.4
 	google.golang.org/grpc v1.79.2
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
-	github.com/infodancer/msgstore v0.2.2-0.20260303202932-60ef82df8079 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect


### PR DESCRIPTION
## Summary

- Adds `client/` package exporting `Dial`, `Login`, `Logout`, `NewMessageStore`, and `Close`
- `MessageStore` implements both `msgstore.MessageStore` and `msgstore.FolderStore`, proxying all MailboxService and FolderService RPCs through the session-manager with the session token in outgoing gRPC metadata
- Covers all operations needed by pop3d (List, Stat, Retrieve, Delete, Expunge) and imapd (full folder/flag/append/copy/move/rescan surface)

## Test plan

- [ ] `go build ./client/...` passes (verified locally)
- [ ] pop3d integration PR (infodancer/pop3d#31) uses this package end-to-end

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)