### PR TITLE
SetupAuth: use WithDefaults for domains missing [auth]/[msgstore]

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -458,14 +458,29 @@ func SetupAuth(cfg *config.Config) (*domain.AuthRouter, error) {
 		return nil, fmt.Errorf("domains_path is required")
 	}
 
-	domainProvider := domain.NewFilesystemDomainProvider(cfg.DomainsPath, nil)
-	if cfg.DomainsDataPath != "" {
-		domainProvider = domainProvider.WithDataPath(cfg.DomainsDataPath)
-	}
-
 	agentType := cfg.Auth.AgentType
 	if agentType == "" {
 		agentType = "passwd"
+	}
+
+	// Domain defaults: domains without [auth] or [msgstore] sections inherit
+	// these values. Matches the defaults used by credentials.Lookup.
+	defaults := domain.DomainConfig{
+		Auth: domain.DomainAuthConfig{
+			Type:              agentType,
+			CredentialBackend: cfg.Auth.CredentialBackend,
+			KeyBackend:        cfg.Auth.KeyBackend,
+		},
+		MsgStore: domain.DomainMsgStoreConfig{
+			Type:     "maildir",
+			BasePath: "users",
+		},
+	}
+
+	domainProvider := domain.NewFilesystemDomainProvider(cfg.DomainsPath, nil).
+		WithDefaults(defaults)
+	if cfg.DomainsDataPath != "" {
+		domainProvider = domainProvider.WithDataPath(cfg.DomainsDataPath)
 	}
 
 	authAgent, err := auth.OpenAuthAgent(auth.AuthAgentConfig{


### PR DESCRIPTION
Fixes #7

## Changes

- `SetupAuth` now calls `WithDefaults` on the `FilesystemDomainProvider` using the `[session-manager.auth]` config values and the standard msgstore defaults (type=maildir, base\_path=users)
- Domains with partial or no `config.toml` now inherit these defaults via `mergeConfig` rather than failing with "auth agent type not registered"
- Matches the fallback behaviour already present in `credentials.Lookup`

## Test plan

- [ ] Existing manager tests pass (`task test`)
- [ ] Session-manager on docker-mail successfully loads matthewjayhunter.com and other domains that only have `forwards = {}` in their config
- [ ] IMAP/POP3 login succeeds end-to-end through session-manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)