### PR TITLE
credentials.Lookup: resolve relative base_path against DomainsDataPath

### DIFF
--- a/internal/credentials/lookup.go
+++ b/internal/credentials/lookup.go
@@ -22,7 +22,11 @@ type Info struct {
 
 // Lookup resolves credentials for username (localpart@domain) using the
 // per-domain config and passwd files under domainsPath.
-func Lookup(domainsPath, localpart, domainName string) (*Info, error) {
+//
+// domainsDataPath, if non-empty, is used to resolve relative MsgStore.BasePath
+// values — matching the behaviour of FilesystemDomainProvider.WithDataPath.
+// Credential backend paths are always resolved relative to domainsPath.
+func Lookup(domainsPath, domainsDataPath, localpart, domainName string) (*Info, error) {
 	domainDir := filepath.Join(domainsPath, domainName)
 
 	cfg, err := domain.LoadDomainConfig(filepath.Join(domainDir, "config.toml"))
@@ -47,12 +51,18 @@ func Lookup(domainsPath, localpart, domainName string) (*Info, error) {
 	}
 
 	// Resolve mail-session basePath (default: "users").
+	// Relative paths are resolved against the data dir when set, matching
+	// FilesystemDomainProvider.WithDataPath behaviour.
 	base := cfg.MsgStore.BasePath
 	if base == "" {
 		base = "users"
 	}
 	if !filepath.IsAbs(base) {
-		base = filepath.Join(domainDir, base)
+		storageBase := domainDir
+		if domainsDataPath != "" {
+			storageBase = filepath.Join(domainsDataPath, domainName)
+		}
+		base = filepath.Join(storageBase, base)
 	}
 
 	storeType := cfg.MsgStore.Type

--- a/internal/credentials/lookup_test.go
+++ b/internal/credentials/lookup_test.go
@@ -34,7 +34,7 @@ credential_backend = "passwd"
 		t.Fatal(err)
 	}
 
-	info, err := Lookup(domainsDir, "alice", "example.com")
+	info, err := Lookup(domainsDir, "", "alice", "example.com")
 	if err != nil {
 		t.Fatalf("Lookup() error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestLookup_MissingUser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := Lookup(domainsDir, "nonexistent", "example.com")
+	_, err := Lookup(domainsDir, "", "nonexistent", "example.com")
 	if err == nil {
 		t.Fatal("expected error for nonexistent user")
 	}
@@ -86,7 +86,7 @@ func TestLookup_Defaults(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	info, err := Lookup(domainsDir, "bob", "example.com")
+	info, err := Lookup(domainsDir, "", "bob", "example.com")
 	if err != nil {
 		t.Fatalf("Lookup() error: %v", err)
 	}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -189,7 +189,7 @@ func (m *Manager) DeliverySession(ctx context.Context, recipient string) (pb.Del
 		return nil, nil, fmt.Errorf("invalid recipient %q: missing @domain", recipient)
 	}
 
-	creds, err := credentials.Lookup(m.cfg.DomainsPath, localpart, domainName)
+	creds, err := credentials.Lookup(m.cfg.DomainsPath, m.cfg.DomainsDataPath, localpart, domainName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("credential lookup for %q: %w", recipient, err)
 	}
@@ -279,7 +279,7 @@ func (m *Manager) spawnSession(username, mailbox string) (*sessionEntry, error) 
 		return nil, fmt.Errorf("invalid username %q: missing @domain", username)
 	}
 
-	creds, err := credentials.Lookup(m.cfg.DomainsPath, localpart, domainName)
+	creds, err := credentials.Lookup(m.cfg.DomainsPath, m.cfg.DomainsDataPath, localpart, domainName)
 	if err != nil {
 		return nil, fmt.Errorf("credential lookup: %w", err)
 	}


### PR DESCRIPTION
Fixes #10

## Changes

- Added `domainsDataPath` parameter to `credentials.Lookup`
- Relative `MsgStore.BasePath` values now resolve against `{domainsDataPath}/{domain}` when set, matching `FilesystemDomainProvider.WithDataPath`
- Updated both `spawnSession` and `DeliverySession` callsites to pass `cfg.DomainsDataPath`
- Updated tests to pass `""` for `domainsDataPath` (preserves existing behaviour)

## Test plan

- [ ] CI passes
- [ ] IMAP/POP3 login succeeds and mailbox opens without permission denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)