### PR TITLE
Add message tracing logs to delivery proxy and outbound handler

### DIFF
--- a/internal/grpcserver/delivery_proxy.go
+++ b/internal/grpcserver/delivery_proxy.go
@@ -3,6 +3,7 @@ package grpcserver
 import (
 	"fmt"
 	"io"
+	"log/slog"
 
 	pb "github.com/infodancer/mail-session/proto/mailsession/v1"
 	"github.com/infodancer/session-manager/internal/manager"
@@ -32,9 +33,16 @@ func (p *deliveryProxy) Deliver(stream pb.DeliveryService_DeliverServer) error {
 		return fmt.Errorf("first chunk must contain delivery metadata")
 	}
 
+	slog.Info("delivery request",
+		"to", meta.Recipient,
+		"from", meta.Sender)
+
 	// Spawn oneshot mail-session for this recipient.
 	deliveryCl, cleanup, err := p.mgr.DeliverySession(stream.Context(), meta.Recipient)
 	if err != nil {
+		slog.Warn("delivery session failed",
+			"to", meta.Recipient,
+			"error", err)
 		return err
 	}
 	defer cleanup()
@@ -56,8 +64,15 @@ func (p *deliveryProxy) Deliver(stream pb.DeliveryService_DeliverServer) error {
 		if err == io.EOF {
 			resp, err := upstream.CloseAndRecv()
 			if err != nil {
+				slog.Warn("delivery failed",
+					"to", meta.Recipient,
+					"from", meta.Sender,
+					"error", err)
 				return err
 			}
+			slog.Info("delivery complete",
+				"to", meta.Recipient,
+				"from", meta.Sender)
 			return stream.SendAndClose(resp)
 		}
 		if err != nil {

--- a/internal/grpcserver/outbound.go
+++ b/internal/grpcserver/outbound.go
@@ -58,6 +58,8 @@ func (s *outboundServer) Enqueue(stream pb.OutboundService_EnqueueServer) error 
 		}
 	}
 
+	bodySize := body.Len()
+
 	// Configure DKIM signing for this sender domain.
 	cfg := s.queueCfg
 	senderDomain := extractSenderDomain(meta.Sender)
@@ -70,18 +72,30 @@ func (s *outboundServer) Enqueue(stream pb.OutboundService_EnqueueServer) error 
 		cfg.DKIMSign = func(domain string, msg io.Reader) (io.Reader, error) {
 			return queue.SignDKIM(domain, selector, key, msg)
 		}
+		slog.Info("DKIM signing enabled",
+			"domain", senderDomain,
+			"selector", selector,
+			"from", meta.Sender)
+	} else if err == nil {
+		slog.Debug("no DKIM key configured",
+			"domain", senderDomain)
 	}
 
 	// Write to queue.
 	msgID, err := queue.Write(cfg, meta.Sender, meta.Recipients, &body)
 	if err != nil {
+		slog.Warn("queue write failed",
+			"from", meta.Sender,
+			"to", meta.Recipients,
+			"error", err)
 		return fmt.Errorf("queue write: %w", err)
 	}
 
 	slog.Info("message enqueued",
-		"msgid", msgID,
-		"sender", meta.Sender,
-		"recipients", meta.Recipients)
+		"msg_id", msgID,
+		"from", meta.Sender,
+		"to", meta.Recipients,
+		"size", bodySize)
 
 	return stream.SendAndClose(&pb.EnqueueResponse{
 		MessageId: msgID,


### PR DESCRIPTION
## Summary
- Add structured logging to `delivery_proxy.go` — logs delivery request, success, and failure with `from`/`to` fields
- Improve `outbound.go` logging — DKIM signing status, queue write failures, consistent field names (`from`/`to`/`msg_id`/`size`) matching smtpd's tracing fields

Closes #20

## Test plan
- [ ] `go test ./...` passes
- [ ] Deploy and verify delivery logs appear in session-manager output
- [ ] Verify `msg_id` from enqueue log correlates with queue-manager pickup

🤖 Generated with [Claude Code](https://claude.com/claude-code)