### PR TITLE
Add [server] support for domains_path and domains_data_path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,21 +115,46 @@ type AuthConfig struct {
 	KeyBackend string `toml:"key_backend"`
 }
 
+// ServerConfig holds shared settings from the [server] section.
+type ServerConfig struct {
+	Hostname        string `toml:"hostname"`
+	DomainsPath     string `toml:"domains_path"`
+	DomainsDataPath string `toml:"domains_data_path"`
+	Maildir         string `toml:"maildir"` // alias for domains_data_path (used by webadmin)
+}
+
+// fileConfig is the parse target for the shared config file.
+type fileConfig struct {
+	Server         ServerConfig `toml:"server"`
+	SessionManager Config       `toml:"session-manager"`
+}
+
 // Load reads the config from a TOML file.
+// Global settings (domains_path, domains_data_path) are read from [server];
+// session-manager-specific settings come from [session-manager].
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
 
-	// Wrap in a top-level section.
-	var wrapper struct {
-		SessionManager Config `toml:"session-manager"`
-	}
-	if err := toml.Unmarshal(data, &wrapper); err != nil {
+	var fc fileConfig
+	if err := toml.Unmarshal(data, &fc); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
-	cfg := &wrapper.SessionManager
+	cfg := &fc.SessionManager
+
+	// Merge [server] globals into session-manager config.
+	if cfg.DomainsPath == "" && fc.Server.DomainsPath != "" {
+		cfg.DomainsPath = fc.Server.DomainsPath
+	}
+	if cfg.DomainsDataPath == "" {
+		if fc.Server.DomainsDataPath != "" {
+			cfg.DomainsDataPath = fc.Server.DomainsDataPath
+		} else if fc.Server.Maildir != "" {
+			cfg.DomainsDataPath = fc.Server.Maildir
+		}
+	}
 
 	// Parse idle timeout.
 	if cfg.IdleTimeoutStr != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,6 +69,89 @@ mail_session_cmd = "/usr/local/bin/mail-session"
 	}
 }
 
+func TestLoad_DomainsPathFromServer(t *testing.T) {
+	// domains_path and domains_data_path should come from [server] when
+	// not set in [session-manager].
+	content := `
+[server]
+domains_path = "/etc/infodancer/domains"
+domains_data_path = "/opt/infodancer/domains"
+
+[session-manager]
+socket = "/tmp/test.sock"
+mail_session_cmd = "/usr/local/bin/mail-session"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.DomainsPath != "/etc/infodancer/domains" {
+		t.Errorf("DomainsPath = %q, want %q (from [server])", cfg.DomainsPath, "/etc/infodancer/domains")
+	}
+	if cfg.DomainsDataPath != "/opt/infodancer/domains" {
+		t.Errorf("DomainsDataPath = %q, want %q (from [server])", cfg.DomainsDataPath, "/opt/infodancer/domains")
+	}
+}
+
+func TestLoad_DomainsPathFromServerMaildir(t *testing.T) {
+	// maildir in [server] acts as a fallback alias for domains_data_path.
+	content := `
+[server]
+domains_path = "/etc/mail/domains"
+maildir = "/var/mail/data"
+
+[session-manager]
+socket = "/tmp/test.sock"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.DomainsDataPath != "/var/mail/data" {
+		t.Errorf("DomainsDataPath = %q, want %q (from [server].maildir)", cfg.DomainsDataPath, "/var/mail/data")
+	}
+}
+
+func TestLoad_SessionManagerPathsOverrideServer(t *testing.T) {
+	// If [session-manager] sets paths, they take precedence over [server].
+	content := `
+[server]
+domains_path = "/etc/shared/domains"
+
+[session-manager]
+socket = "/tmp/test.sock"
+domains_path = "/etc/sm/domains"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.DomainsPath != "/etc/sm/domains" {
+		t.Errorf("DomainsPath = %q, want %q ([session-manager] should win)", cfg.DomainsPath, "/etc/sm/domains")
+	}
+}
+
 func TestLoad_InvalidIdleTimeout(t *testing.T) {
 	content := `
 [session-manager]


### PR DESCRIPTION
## Summary

- Add `ServerConfig` struct and `fileConfig` wrapper to read from `[server]`
- Merge `domains_path` and `domains_data_path` from `[server]` as fallback when not set in `[session-manager]`
- `maildir` in `[server]` acts as alias for `domains_data_path`
- `[session-manager]` values still take precedence if explicitly set
- Add tests for server fallback, maildir alias, and override behavior

## Test plan

- [x] `TestLoad_DomainsPathFromServer` — paths come from `[server]` when not in `[session-manager]`
- [x] `TestLoad_DomainsPathFromServerMaildir` — maildir alias works
- [x] `TestLoad_SessionManagerPathsOverrideServer` — explicit `[session-manager]` paths win
- [x] All existing tests still pass
- [x] Full test suite passes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)